### PR TITLE
Fix query param generation

### DIFF
--- a/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
+++ b/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
@@ -5,18 +5,5 @@ import type { Widget } from "../Widget.js";
  * An endpoint for retrieving all widgets, with optional filtering by the date of widget creation.
  */
 export async function getWidgets(ctx: ConjureContext, createdAfter: string, containingProperties: Array<string>): Promise<Array<Widget>> {
-    return conjureFetch(ctx, `/widgets?${new URLSearchParams(Object.entries({ "createdAfter": createdAfter,"containingProperties": containingProperties.join(",") }).reduce(
-  (acc, [key, value]) => {
-    if (value == null) {
-      return acc;
-    }
-    const paramValue = "" + value;
-    if (paramValue.length === 0) {
-      return acc;
-    }
-    acc[key] = paramValue;
-    return acc;
-  },
-  {} as { [key: string]: string },
-))}`, "GET")
-  }
+  return conjureFetch(ctx, `/widgets`, "GET", undefined, { "createdAfter": createdAfter,"containingProperties": containingProperties })
+}

--- a/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
+++ b/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
@@ -5,5 +5,18 @@ import type { Widget } from "../Widget.js";
  * An endpoint for retrieving all widgets, with optional filtering by the date of widget creation.
  */
 export async function getWidgets(ctx: ConjureContext, createdAfter: string, containingProperties: Array<string>): Promise<Array<Widget>> {
-  return conjureFetch(ctx, `/widgets?${new URLSearchParams({ "createdAfter": "" + createdAfter,"containingProperties": containingProperties.join(",") })}`, "GET")
-}
+    return conjureFetch(ctx, `/widgets?${new URLSearchParams(Object.entries({ "createdAfter": createdAfter,"containingProperties": containingProperties.join(",") }).reduce(
+  (acc, [key, value]) => {
+    if (value == null) {
+      return acc;
+    }
+    const paramValue = "" + value;
+    if (paramValue.length === 0) {
+      return acc;
+    }
+    acc[key] = paramValue;
+    return acc;
+  },
+  {} as { [key: string]: string },
+))}`, "GET")
+  }

--- a/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
+++ b/examples/widget/src/generated/widget/WidgetService/getWidgets.ts
@@ -5,5 +5,5 @@ import type { Widget } from "../Widget.js";
  * An endpoint for retrieving all widgets, with optional filtering by the date of widget creation.
  */
 export async function getWidgets(ctx: ConjureContext, createdAfter: string, containingProperties: Array<string>): Promise<Array<Widget>> {
-  return conjureFetch(ctx, `/widgets`, "GET", undefined, { "createdAfter": createdAfter,"containingProperties": containingProperties })
+  return conjureFetch(ctx, `/widgets`, "GET", undefined, { createdAfter,containingProperties })
 }

--- a/src/codegen/EndpointCodeFile.ts
+++ b/src/codegen/EndpointCodeFile.ts
@@ -14,13 +14,12 @@ export const endpointCodeGenerator = generatorFactory<IEndpointDefinition>(
     const queryParams = (this.def.args ?? []).filter(isQueryArgument);
     const queryArg = queryParams.length === 0 ? undefined : `{ ${
         queryParams.map(a => {
-            // a.type.type === "primitive"  && a.type.primitive === ""
             if (a.type.type === "map") {
               throw new Error(
                 `Unsupported type ${a.type.type} while generating ${this.def.endpointName}`,
               );
             }
-            return `"${a.paramType.query.paramId}": ${a.argName}`;
+            return a.paramType.query.paramId === a.argName ? a.paramType.query.paramId : `"${a.paramType.query.paramId}": ${a.argName}`;
         }).join(",")
     } }`;
 

--- a/src/codegen/EndpointCodeFile.ts
+++ b/src/codegen/EndpointCodeFile.ts
@@ -1,4 +1,4 @@
-import type { IEndpointDefinition, IType } from "conjure-api";
+import type { IArgumentDefinition, IEndpointDefinition, IParameterType_Query, IType } from "conjure-api";
 import dedent from "dedent";
 import { calculateTemplatedUrlForEndpoint } from "./calculateTemplatedUrlForEndpoint.js";
 import { generatorFactory } from "./generatorFactory.js";
@@ -11,6 +11,19 @@ export const endpointCodeGenerator = generatorFactory<IEndpointDefinition>(
     const bodyArg = (this.def.args ?? []).find(a => a.paramType.type === "body");
     const bodyArgContentType = getContentType(bodyArg?.type);
 
+    const queryParams = (this.def.args ?? []).filter(isQueryArgument);
+    const queryArg = queryParams.length === 0 ? undefined : `{ ${
+        queryParams.map(a => {
+            // a.type.type === "primitive"  && a.type.primitive === ""
+            if (a.type.type === "map") {
+              throw new Error(
+                `Unsupported type ${a.type.type} while generating ${this.def.endpointName}`,
+              );
+            }
+            return `"${a.paramType.query.paramId}": ${a.argName}`;
+        }).join(",")
+    } }`;
+
     const acceptContentType = getContentType(this.def.returns);
 
     this.imports.set(
@@ -22,7 +35,8 @@ export const endpointCodeGenerator = generatorFactory<IEndpointDefinition>(
       "ctx",
       templatedUrl,
       `"${this.def.httpMethod}"`,
-      bodyArg?.argName,
+      bodyArg == null && queryArg ? "undefined" : bodyArg?.argName,
+      queryArg,
       bodyArgContentType === "application/json" ? undefined : bodyArgContentType,
       acceptContentType === "application/json" ? undefined : acceptContentType,
     ];
@@ -56,4 +70,10 @@ export function getContentType(arg: IType | undefined | null) {
 
 function isBinary(type: IType) {
   return type.type === "primitive" && type.primitive === "BINARY";
+}
+
+function isQueryArgument(
+    a: IArgumentDefinition,
+): a is IArgumentDefinition & { paramType: IParameterType_Query } {
+    return a.paramType.type === "query";
 }

--- a/src/codegen/calculateTemplatedUrlForEndpoint.ts
+++ b/src/codegen/calculateTemplatedUrlForEndpoint.ts
@@ -1,52 +1,7 @@
-import type { IArgumentDefinition, IEndpointDefinition, IParameterType_Query } from "conjure-api";
+import type { IEndpointDefinition } from "conjure-api";
 
 export function calculateTemplatedUrlForEndpoint(endpoint: IEndpointDefinition) {
   const args = endpoint.args ?? [];
-  const queryArgs = args.filter(isQueryArgument) ?? [];
-  const queryPortion = queryArgs.length === 0
-    ? ""
-    : "?${" + `new URLSearchParams(Object.entries({ ${
-      queryArgs.map(a => {
-        // a.type.type === "primitive"  && a.type.primitive === ""
-        switch (a.type.type) {
-          case "map":
-            throw new Error(
-              `Unsupported type ${a.type.type} while generating ${endpoint.endpointName}`,
-            );
-          case "list":
-          case "set":
-            return `"${a.paramType.query.paramId}": ${a.argName}.join(",")`;
-
-          case "reference":
-            return `"${a.paramType.query.paramId}": ${a.argName}`;
-          case "primitive":
-            switch (a.type.primitive) {
-              case "STRING":
-              case "BEARERTOKEN":
-              case "RID":
-              case "UUID":
-                return `"${a.paramType.query.paramId}": ${a.argName}`;
-            }
-        }
-
-        return `"${a.paramType.query.paramId}": ${a.argName}`;
-      }).join(",")
-      // omit undefined or empty query values
-    } }).reduce(
-      (acc, [key, value]) => {
-        if (value == null) {
-          return acc;
-        }
-        const paramValue = "" + value;
-        if (paramValue.length === 0) {
-          return acc;
-        }
-        acc[key] = paramValue;
-        return acc;
-      },
-      {} as { [key: string]: string },
-    )` + ")}";
-
   return "`" + args.reduce(
     (p, c) => {
       if (c.paramType.type === "path") {
@@ -55,11 +10,5 @@ export function calculateTemplatedUrlForEndpoint(endpoint: IEndpointDefinition) 
       return p;
     },
     endpoint.httpPath,
-  ) + queryPortion + "`";
-}
-
-function isQueryArgument(
-  a: IArgumentDefinition,
-): a is IArgumentDefinition & { paramType: IParameterType_Query } {
-  return a.paramType.type === "query";
+  ) + "`";
 }

--- a/src/conjureFetch.ts
+++ b/src/conjureFetch.ts
@@ -29,20 +29,17 @@ export async function conjureFetch<T>(
     }
   }
 
-  const queryParams = Object.entries(params ?? {}).reduce(
-      (acc, [key, value]) => {
-        // omit undefined, null and empty parameter values
+  const queryParams = Object.entries(params ?? {}).flatMap(
+      ( [key, value]) => {
         if (value == null) {
-          return acc;
+          return [];
         }
-        const paramValue = Array.isArray(value) ? value.join(",") : "" + value;
-        if (paramValue.length === 0) {
-          return acc;
+        if (Array.isArray(value)) {
+          return value.map(item => ([key, item]));
         }
-        acc[key] = paramValue;
-        return acc;
+        const stringValue = "" + value;
+        return stringValue.length === 0 ? [] : [[key, stringValue]];
       },
-      {} as { [key: string]: string },
   )
   const query = Object.keys(queryParams).length === 0 ? "" : `?${new URLSearchParams(queryParams).toString()}`;
 


### PR DESCRIPTION
Changes query param generation to that empty/undefined query param values are omitted. This includes empty arrays.

It'd perhaps be nicer to have a utility function that could be imported into the generated code rather than inlining the logic for all endpoints?