### PR TITLE
Add typing for `"NaN"`, `"Infinity"` and `"-Infinity"` double cases

### DIFF
--- a/src/codegen/BaseFileGenerator.ts
+++ b/src/codegen/BaseFileGenerator.ts
@@ -120,7 +120,7 @@ export class BaseFileGenerator<
           case "DATETIME":
             return "string";
           case "DOUBLE":
-            return "number";
+            return `number | "NaN" | "Infinity" | "-Infinity"`;
           case "INTEGER":
             return "number";
           case "RID":


### PR DESCRIPTION
The Conjure wire specification for doubles states that when a Conjure type is either serialized into or deserialized from JSON, `"NaN"`, `"Infinity"` and `"-Infinity"` can be used as the JSON type: https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#51-built-in-types