### PR TITLE
Update binary type code generation

### DIFF
--- a/src/codegen/BaseFileGenerator.ts
+++ b/src/codegen/BaseFileGenerator.ts
@@ -114,7 +114,7 @@ export class BaseFileGenerator<
           case "BEARERTOKEN":
             return "string";
           case "BINARY":
-            return "Blob";
+            return "string";
           case "BOOLEAN":
             return "boolean";
           case "DATETIME":


### PR DESCRIPTION
https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#5-json-format states that when binary fields are serialized to / deserialized from JSON, the data is represented as a base64-encoded string.