### PR TITLE
Add newline at end of union type export

### DIFF
--- a/src/codegen/ComponentsCodeFile.ts
+++ b/src/codegen/ComponentsCodeFile.ts
@@ -61,7 +61,7 @@ export const objectCodeGenerator = generatorFactory<
           + getDocs(docs)
           + dedent`
               export type ${name} = ${union.map(u => `${name}_${u.fieldName}`).join(" | ")}
-            `;
+            \n`;
       }
     }
 


### PR DESCRIPTION
Currently, union type exports do not have a new line character, which causes following type declarations to be generated on the same line like this:

![Screenshot 2025-03-09 at 11 13 39 PM](https://github.com/user-attachments/assets/594991fe-03a1-4d93-91e9-3b77b84c4767)
