### PR TITLE
Add `null` union variant for optional codegen

### DIFF
--- a/src/codegen/BaseFileGenerator.ts
+++ b/src/codegen/BaseFileGenerator.ts
@@ -100,7 +100,7 @@ export class BaseFileGenerator<
         return `Array<${this.getTypeForCode(type.set.itemType)}>`;
 
       case "optional":
-        return `${this.getTypeForCode(type.optional.itemType)} | undefined`;
+        return `${this.getTypeForCode(type.optional.itemType)} | null | undefined`;
 
       case "map":
         return `Record<${this.getTypeForCode(type.map.keyType)}, ${


### PR DESCRIPTION
In the docs for [container types](https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#52-container-types) (which includes optionals), they state that it is valid to set the value of an optional field to `null` in addition to making the field absent (the latter results in an undefined value in JavaScript, which the existing type handles).