### PR TITLE
Fix empty union generation

### DIFF
--- a/src/codegen/ComponentsCodeFile.ts
+++ b/src/codegen/ComponentsCodeFile.ts
@@ -55,12 +55,14 @@ export const objectCodeGenerator = generatorFactory<
             }\n`;
         };
 
+        const joined = union.map(u => `${name}_${u.fieldName}`).join(" | ");
+
         source += dedent`
             ${union.map(createUnionInterface).join("\n")}
             `
           + getDocs(docs)
           + dedent`
-              export type ${name} = ${union.map(u => `${name}_${u.fieldName}`).join(" | ")}
+              export type ${name} = ${joined == "" ? "{}" : joined}
             \n`;
       }
     }


### PR DESCRIPTION
Empty unions were not being generated correctly.

Example IR:
```
{
  "version": 1,
  "errors": [],
  "types": [
    {
      "type": "union",
      "union": {
        "typeName": {
          "name": "ThisIsAnEmptyUnion",
          "package": "this.is.the.package"
        },
        "union": []
      }
    }
  ],
  "services": []
}
```
---
Before:
```
export type ThisIsAnEmptyUnion =
```
After:
```
export type ThisIsAnEmptyUnion = {}
``` 
