### PR TITLE
Fix missing "fields" deserialisation

### DIFF
--- a/src/codegen/ComponentsCodeFile.ts
+++ b/src/codegen/ComponentsCodeFile.ts
@@ -18,7 +18,7 @@ export const objectCodeGenerator = generatorFactory<
     ) {
       if (def.type === "object") {
         const { typeName: { name }, docs } = def.object;
-        const fields = def.object.fields
+        const fields = (def.object.fields ?? [])
           .sort((a, b) => a.fieldName.localeCompare(b.fieldName))
           .map(f =>
             `  ${


### PR DESCRIPTION
The definition for conjure IR is itself conjure, and lives here - https://github.com/palantir/conjure/blob/2be23aab56a6ccab87f69f3661df1a59c0ae5fb6/conjure-api/src/main/conjure/conjure-api.yml#L139.

In the conjure spec, when a field is a collection type and missing it is interpreted as an empty list - see https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#561-coercing-json-null--absent-to-conjure-types.

That means we need to handle empty/missing correctly here
